### PR TITLE
Fix trailing whitespace in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 - 👋 Hi, I’m @kneil31
 - 👀 I’m interested in cloud deployments
 - 🌱 I’m currently learning GKE Pega deployments
-- 💞️ I’m looking to collaborate on pega cloud deployments 
+- 💞️ I’m looking to collaborate on pega cloud deployments
 - 📫 you can reach me at reddy531@yahoo.com
 
 <!---


### PR DESCRIPTION
## Summary
- trim trailing whitespace in README

## Testing
- `grep -n " \+$" README.md`
